### PR TITLE
Make library compatible with OpenWaves.EPiServer.GeoProperties for easier migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ How to use: http://tedgustaf.com/blog/2014/10/google-maps-custom-editor-for-epis
 Source code: https://github.com/tedgustaf/episerver-google-maps-editor
 
 Available on the EPiServer NuGet feed: http://nuget.episerver.com/feed/packages.svc/
+
+Note: Compatible with custom properties used by OpenWaves.EPiServer.GeoProperties. Just change OpenWave's custom property type to string, and the zoom level contained within that string will be eventually migrated over by this addon.

--- a/nuget/content/ClientResources/googlemaps/Editor.js
+++ b/nuget/content/ClientResources/googlemaps/Editor.js
@@ -172,8 +172,9 @@ function (
 
             if (typeof this.value === "string") {
                 var coordinates = this.value.split(',');
-
-                if (coordinates.length != 2) { // Valid value is longitude and latitude, separated by a comma
+                
+                // Valid value is longitude and latitude, and an optional zoom level parameter which is not used, separated by a comma
+                if (coordinates.length !== 2 && coordinates.length !== 3) {
                     return false;
                 }
 
@@ -206,7 +207,8 @@ function (
             }
 
             if (typeof this.value === "string") {
-                return this.value.split(',').length == 2; // String value with comma-separated coordinates
+                var parameterCount = this.value.split(',').length;
+                return parameterCount === 2 || parameterCount === 3; // String value with comma-separated coordinates
             } else if (typeof this.value === "object") { // Complex type with separate properties for latitude and longitude
                 return this.value.longitude !== undefined &&
                        this.value.latitude !== undefined &&


### PR DESCRIPTION
If we support init values that have 3 parameters, the addon is directly compatible with OpenWaves.EPiServer.GeoProperties, and makes it easier for anyone using said library to migrate over to this one, without having to make a data migrator.

The custom property that OpenWave uses is proprietery to their library, but uses a basetype of string. This string has an otherwise compatible format with this addon, aside from containing a third parameter, which is the zoom level.

OpenWaves has no support for the latest episerver, which is why I for example switched our projects over to use this library.